### PR TITLE
Replace exclude with dump_only

### DIFF
--- a/src/map_storage/resources.py
+++ b/src/map_storage/resources.py
@@ -45,7 +45,7 @@ class Maps(MethodResource):
             maps = maps.filter(MapModel.model_id == model_id)
         return maps.all()
 
-    @use_kwargs(Map(exclude=('id',)))
+    @use_kwargs(Map)
     @marshal_with(None, code=201)
     @marshal_with(None, code=401)
     @marshal_with(None, code=403)
@@ -77,7 +77,7 @@ class Map(MethodResource):
         except NoResultFound:
             abort(404, f"Cannot find map with id {map_id}")
 
-    @use_kwargs(Map(exclude=('id',), partial=True))
+    @use_kwargs(Map(partial=True))
     @marshal_with(None, code=200)
     @marshal_with(None, code=401)
     @marshal_with(None, code=403)

--- a/src/map_storage/schemas.py
+++ b/src/map_storage/schemas.py
@@ -29,7 +29,7 @@ class MapListFilter(StrictSchema):
 
 
 class Map(StrictSchema):
-    id = fields.Integer(required=True)
+    id = fields.Integer(dump_only=True)
     project_id = fields.Integer(required=True)
     name = fields.String(required=True)
     model_id = fields.Integer(required=True)


### PR DESCRIPTION
Setting this in the schema appears to be a slightly better pattern than having to explicitly exclude the id field in the appropriate endpoints.