### PR TITLE
refactor: permit `additionalProperties` in escher schema

### DIFF
--- a/jsonschema/1-0-0
+++ b/jsonschema/1-0-0
@@ -80,7 +80,7 @@
                             "required": ["name", "bigg_id","reversibility",
                                          "label_x", "label_y", "gene_reaction_rule",
                                          "genes", "metabolites", "segments"],
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "name": {"type": "string"},
                                 "bigg_id": {"type": "string"},
@@ -93,7 +93,7 @@
                                     "items": {
                                         "type": "object",
                                         "required_properties": ["bigg_id", "name"],
-                                        "additionalProperties": false,
+                                        "additionalProperties": true,
                                         "properties": {
                                             "bigg_id": {"type": "string"},
                                             "name": {"type": "string"}
@@ -105,7 +105,7 @@
                                     "items": {
                                         "type": "object",
                                         "required": ["coefficient", "bigg_id"],
-                                        "additionalProperties": false,
+                                        "additionalProperties": true,
                                         "properties": {
                                             "coefficient": {"type": "number"},
                                             "bigg_id": {"type": "string"}

--- a/jsonschema/README
+++ b/jsonschema/README
@@ -1,1 +1,3 @@
 Schema downloaded from: https://github.com/zakandrewking/escher/tree/master/jsonschema
+
+A few `additionalProperties: true` have been set to accommodate maps that used notes fields.


### PR DESCRIPTION
`additionalProperties: true` has been set for `reactions`, `metabolites`, and `genes` to accommodate maps that use notes fields (for example https://github.com/search?q=original_bigg_ids&type=Code).